### PR TITLE
Disable frustum culling for instanced meshes

### DIFF
--- a/ball.js
+++ b/ball.js
@@ -33,6 +33,7 @@ export function loadBall(){
         scrubMaterial(mat);
 
         ballMesh = new THREE.InstancedMesh(geom, mat, MAX_POOL_BALLS);
+        ballMesh.frustumCulled = false;
         ballMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 
         const arr = new Float32Array(MAX_POOL_BALLS*4);

--- a/hazard.js
+++ b/hazard.js
@@ -30,6 +30,7 @@ function makeMaterial(){
 
 const geo = new THREE.IcosahedronGeometry(HAZARD_RADIUS, 1);
 const mesh = new THREE.InstancedMesh(geo, makeMaterial(), MAX_HAZARDS);
+mesh.frustumCulled = false;
 mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
 
 const arr = new Float32Array(MAX_HAZARDS*4);


### PR DESCRIPTION
## Summary
- disable frustum culling for ball instanced mesh
- disable frustum culling for hazard instanced mesh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b89374b234832e818e64b94a102da0