### PR TITLE
Add visual hit/miss overlays

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,0 +1,28 @@
+let overlay;
+function ensureOverlay(){
+  if (!overlay){
+    overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.width = '100%';
+    overlay.style.height = '100%';
+    overlay.style.pointerEvents = 'none';
+    overlay.style.opacity = '0';
+    overlay.style.transition = 'opacity 150ms';
+    overlay.style.zIndex = '9999';
+    document.body.appendChild(overlay);
+  }
+}
+function flash(color){
+  ensureOverlay();
+  overlay.style.background = color;
+  overlay.style.opacity = '1';
+  requestAnimationFrame(()=>{ overlay.style.opacity = '0'; });
+}
+export function flashHit(){
+  flash('rgba(0,255,0,0.35)');
+}
+export function flashMiss(){
+  flash('rgba(255,255,100,0.35)');
+}

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ import { getHazardMesh, getHazardAttribute, allocHazard, freeHazard } from './ha
 import { hitSound, missSound, penaltySound } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
+import { flashHit, flashMiss } from './effects.js';
 
 /* ============================ Renderer ============================ */
 const renderer = new THREE.WebGLRenderer({
@@ -436,11 +437,15 @@ function onBallHit(b){
   b.alive=false; freeBall(b.index);
   hits++; streak++; score+=comboMultiplier();
   const now=performance.now(); if (AUDIO_ENABLED && now-_lastHitAt>40){ hitSound(); _lastHitAt=now; }
-  rumble(0.9,60); updateHUD();
+  rumble(0.9,60);
+  flashHit();
+  updateHUD();
 }
 function onBallMiss(b){
   b.alive=false; freeBall(b.index);
-  misses++; streak=0; if (AUDIO_ENABLED) missSound(); rumble(0.25,40); updateHUD();
+  misses++; streak=0; if (AUDIO_ENABLED) missSound(); rumble(0.25,40);
+  flashMiss();
+  updateHUD();
 }
 function onHazardHit(h){
   h.alive=false; freeHazard(h.index);


### PR DESCRIPTION
## Summary
- add effects utility to flash color overlays
- invoke overlay flashes on ball hits and misses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94d9a0cc8832eae88b83a3f8179d6