### PR TITLE
Add hazard flash overlay for hazard hits

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -26,3 +26,31 @@ export function flashHit(){
 export function flashMiss(){
   flash('rgba(255,255,100,0.35)');
 }
+
+// Hazard flash overlay with red edges and quick fade-out
+let hazardOverlay;
+function ensureHazardOverlay(){
+  if (!hazardOverlay){
+    hazardOverlay = document.createElement('div');
+    hazardOverlay.style.position = 'fixed';
+    hazardOverlay.style.top = '0';
+    hazardOverlay.style.left = '0';
+    hazardOverlay.style.width = '100%';
+    hazardOverlay.style.height = '100%';
+    hazardOverlay.style.pointerEvents = 'none';
+    hazardOverlay.style.opacity = '0';
+    hazardOverlay.style.transition = 'opacity 100ms';
+    hazardOverlay.style.boxShadow = '0 0 0 20px rgba(255,0,0,0.9) inset';
+    hazardOverlay.style.background = 'transparent';
+    hazardOverlay.style.zIndex = '10000';
+    document.body.appendChild(hazardOverlay);
+  }
+}
+
+function startHazardFlash(){
+  ensureHazardOverlay();
+  hazardOverlay.style.opacity = '1';
+  requestAnimationFrame(()=>{ hazardOverlay.style.opacity = '0'; });
+}
+
+export const hazardFlash = { start: startHazardFlash };

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ import { getHazardMesh, getHazardAttribute, allocHazard, freeHazard } from './ha
 import { hitSound, missSound, penaltySound } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
-import { flashHit, flashMiss } from './effects.js';
+import { flashHit, flashMiss, hazardFlash } from './effects.js';
 import { HitParticles } from './hitParticles.js';
 
 /* ============================ Renderer ============================ */
@@ -457,7 +457,10 @@ function onBallMiss(b){
 function onHazardHit(h){
   h.alive=false; freeHazard(h.index);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
-  if (AUDIO_ENABLED) penaltySound(); rumble(1.0,80); updateHUD();
+  if (AUDIO_ENABLED) penaltySound();
+  rumble(1.0,80);
+  hazardFlash.start();
+  updateHUD();
 }
 
 /* ======================= Collision Helpers ======================= */


### PR DESCRIPTION
## Summary
- Add CSS-based `hazardFlash` overlay with red border and fast fade-out.
- Trigger `hazardFlash.start()` when a hazard hits the player.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b94fa24844832eb669577c05f2470f