### PR TITLE
Tune hazard rumble intensity and duration

### DIFF
--- a/config.js
+++ b/config.js
@@ -46,6 +46,9 @@ export const HAZARD_SPEED = BALL_SPEED;
 export const HAZARD_PENALTY = 2;
 export const HAZARD_COLOR = 0xff4242;
 export const HAZARD_EMISSIVE_INTENSITY = 0.9; // damit Hazards „leuchten“ und immer sichtbar sind
+// Kurzer, starker Rumble bei Hazard-Treffern
+export const HAZARD_RUMBLE_INTENSITY = 1.0;   // volle Intensität
+export const HAZARD_RUMBLE_DURATION = 55;     // ms, kurz und kräftig
 
 // --- Debug ---
 export const DEBUG_HAZARD_RING_MS = 0;      // 0 = aus; kurzer Ring-Flash am Hazard-Spawn

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@ import {
   DRIFT_ENABLED, DRIFT_MIN_AMPLITUDE, DRIFT_MAX_AMPLITUDE, DRIFT_MIN_FREQ, DRIFT_MAX_FREQ,
   AUDIO_ENABLED, HAPTICS_ENABLED,
   HAZARD_ENABLED, HAZARD_PROB, HAZARD_RADIUS, HAZARD_SPEED, HAZARD_PENALTY,
+  HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION,
   DEBUG_HAZARD_RING_MS,
   MIN_SPAWN_DISTANCE,
   DISSOLVE_DURATION
@@ -458,7 +459,8 @@ function onHazardHit(h){
   h.alive=false; freeHazard(h.index);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
   if (AUDIO_ENABLED) penaltySound();
-  rumble(1.0,80);
+  // Emphasize hazard impact with short, high-intensity rumble
+  rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
   hazardFlash.start();
   updateHUD();
 }


### PR DESCRIPTION
## Summary
- Add hazard rumble configuration for short 55ms, full intensity vibration
- Use new rumble parameters when hazards hit the player

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b950843280832e891094affb31e874