### PR TITLE
refactor: centralize three.js imports

### DIFF
--- a/ball.js
+++ b/ball.js
@@ -1,5 +1,5 @@
 // ball.js
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { GLTFLoader } from 'https://unpkg.com/three@0.166.1/examples/jsm/loaders/GLTFLoader.js?module';
 import { BALL_RADIUS, BALL_URL, DISSOLVE_DURATION } from './config.js';
 

--- a/fists.js
+++ b/fists.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { XRControllerModelFactory } from 'https://unpkg.com/three@0.166.1/examples/jsm/webxr/XRControllerModelFactory.js?module';
 
 // Options:

--- a/hazard.js
+++ b/hazard.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { HAZARD_RADIUS, HAZARD_COLOR, HAZARD_EMISSIVE_INTENSITY, DRIFT_ENABLED, DISSOLVE_DURATION } from './config.js';
 
 export const MAX_HAZARDS = 32;

--- a/hitParticles.js
+++ b/hitParticles.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { HIT_PARTICLE_COUNT } from './config.js';
 
 export class HitParticles {

--- a/hud.js
+++ b/hud.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { HUD_PLANE_W, HUD_PLANE_H, HUD_FORWARD, HUD_RIGHT, HUD_TILT_DEG } from './config.js';
 
 export function createHUD(scene){

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 import { ARButton } from 'https://unpkg.com/three@0.166.1/examples/jsm/webxr/ARButton.js?module';
 
 import {

--- a/menu.js
+++ b/menu.js
@@ -1,5 +1,5 @@
 // Robustes Menü mit Hit-Plane, 2D-Picking und Zeitmodi
-import * as THREE from 'https://unpkg.com/three@0.166.1/build/three.module.js';
+import * as THREE from './three.js';
 
 function makeCanvasPlane(w, h) {
   const canvas = document.createElement('canvas');

--- a/three.js
+++ b/three.js
@@ -1,0 +1,1 @@
+export * from 'https://unpkg.com/three@0.166.1/build/three.module.js';


### PR DESCRIPTION
## Summary
- add `three.js` that re-exports Three.js 0.166.1 from unpkg
- update all modules to import from local `./three.js`
- ensure no extra Three.js versions are loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b957d813f0832eaa444a26d2ba38b6