### PR TITLE
Add 3D hazard overlay fallback for missing DOM overlay

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,3 +1,5 @@
+import * as THREE from './three.js';
+
 let overlay;
 function ensureOverlay(){
   if (!overlay){
@@ -54,3 +56,22 @@ function startHazardFlash(){
 }
 
 export const hazardFlash = { start: startHazardFlash };
+
+// Fallback effect for environments without DOM overlay
+let hazardPlane;
+export function initHazardFlashFallback(camera){
+  if (hazardPlane) return;
+  const geo = new THREE.PlaneGeometry(2, 2);
+  const mat = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0.35, depthWrite: false });
+  hazardPlane = new THREE.Mesh(geo, mat);
+  hazardPlane.visible = false;
+  hazardPlane.renderOrder = 10000;
+  hazardPlane.position.set(0, 0, -0.5);
+  camera.add(hazardPlane);
+}
+
+export function hazardFlashFallback(){
+  if (!hazardPlane) return;
+  hazardPlane.visible = true;
+  setTimeout(()=>{ hazardPlane.visible = false; }, 300);
+}

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ import { getHazardMesh, getHazardAttribute, allocHazard, freeHazard, dissolveHaz
 import { hitSound, missSound, penaltySound } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
-import { flashHit, flashMiss, hazardFlash } from './effects.js';
+import { flashHit, flashMiss, hazardFlash, initHazardFlashFallback, hazardFlashFallback } from './effects.js';
 import { HitParticles } from './hitParticles.js';
 
 /* ============================ Renderer ============================ */
@@ -65,6 +65,7 @@ renderer.xr.addEventListener('sessionstart', ()=>{
   domOverlayActive = !!session?.domOverlayState;
   if (!domOverlayActive) {
     console.warn('dom-overlay not available, using reduced visual effects');
+    initHazardFlashFallback(camera);
   }
 });
 
@@ -486,6 +487,7 @@ function onHazardHit(h){
   // Emphasize hazard impact with short, high-intensity rumble
   rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
   if (domOverlayActive) hazardFlash.start();
+  else hazardFlashFallback();
   updateHUD();
 }
 


### PR DESCRIPTION
## Summary
- Detect missing DOM overlay and prepare 3D hazard feedback.
- Provide 3D hazard flash fallback effect when DOM overlay unavailable.
- Trigger fallback flash on hazard hits without DOM overlay support.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b95f4d6980832e892f122454e5e30f