### PR TITLE
Restart hazard overlay flash animation

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -51,8 +51,11 @@ function ensureHazardOverlay(){
 
 function startHazardFlash(){
   ensureHazardOverlay();
+  hazardOverlay.style.transition = 'none';
   hazardOverlay.style.opacity = '1';
-  requestAnimationFrame(()=>{ hazardOverlay.style.opacity = '0'; });
+  void hazardOverlay.offsetWidth;
+  hazardOverlay.style.transition = 'opacity 300ms';
+  hazardOverlay.style.opacity = '0';
 }
 
 export const hazardFlash = { start: startHazardFlash };


### PR DESCRIPTION
## Summary
- ensure hazard flash animation resets by toggling transition and forcing reflow before fade-out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b96289dfec832ebf0fcdaf079a465e