### PR TITLE
Improve hazard plane flash visibility

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -63,11 +63,27 @@ export const hazardFlash = { start: startHazardFlash };
 // Plane-based hazard flash effect
 let hazardPlane;
 export function createHazardPlane(camera){
-  const geometry = new THREE.PlaneGeometry(2, 2);
-  const material = new THREE.MeshBasicMaterial({ color: 0xff0000, transparent: true, opacity: 0 });
-  hazardPlane = new THREE.Mesh(geometry, material);
-  hazardPlane.position.set(0, 0, -0.01);
-  camera.add(hazardPlane); // 0.01 vor der Kamera positionieren
+  if (!hazardPlane){
+    const material = new THREE.MeshBasicMaterial({
+      color: 0xff0000,
+      transparent: true,
+      opacity: 0,
+      side: THREE.DoubleSide,
+      depthTest: false,
+      depthWrite: false
+    });
+    hazardPlane = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
+    hazardPlane.renderOrder = 9999;
+  }
+  hazardPlane.position.set(0, 0, -0.4); // weiter vor die Kamera
+  if (hazardPlane.parent) {
+    hazardPlane.parent.remove(hazardPlane);
+  }
+  camera.add(hazardPlane);
+  if (camera.near > 0.01) {
+    camera.near = 0.01;
+    camera.updateProjectionMatrix();
+  }
 }
 
 export function flashHazardPlane(){

--- a/main.js
+++ b/main.js
@@ -46,6 +46,14 @@ scene.add(new THREE.HemisphereLight(0xffffff, 0x444444, 1.0));
 const hitParticles = new HitParticles();
 scene.add(hitParticles.points);
 createHazardPlane(camera);
+
+renderer.xr.addEventListener('sessionstart', () => {
+  createHazardPlane(renderer.xr.getCamera(camera));
+});
+
+renderer.xr.addEventListener('sessionend', () => {
+  createHazardPlane(camera);
+});
 window.addEventListener('resize', () => {
   if (!renderer.xr.isPresenting) {
     renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- adjust hazard plane material to render on both sides without depth testing
- move hazard plane farther in front of camera and ensure near clipping accommodates it
- reattach hazard plane to active WebXR camera for consistent visibility

## Testing
- `node --check effects.js main.js && echo 'Syntax OK'`
- `node --check main.js && echo 'Syntax OK'`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/punch/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b96e349f08832ebda22dbe9b92fb42