### PR TITLE
Switch to overlay-based hazard flash

### DIFF
--- a/effects.js
+++ b/effects.js
@@ -1,5 +1,3 @@
-import * as THREE from './three.js';
-
 let overlay;
 function ensureOverlay(){
   if (!overlay){
@@ -59,29 +57,3 @@ function startHazardFlash(){
 }
 
 export const hazardFlash = { start: startHazardFlash };
-
-// Plane-based hazard flash effect
-let hazardPlane;
-export function createHazardPlane(camera){
-  const material = new THREE.MeshBasicMaterial({
-    color: 0xff0000,
-    transparent: true,
-    opacity: 0,
-    side: THREE.DoubleSide,
-    depthTest: false
-  });
-  hazardPlane = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
-  hazardPlane.position.set(0, 0, -0.4); // weiter vor die Kamera
-  hazardPlane.renderOrder = 9999;
-  camera.add(hazardPlane);
-  if (camera.near > 0.01) {
-    camera.near = 0.01;
-    camera.updateProjectionMatrix();
-  }
-}
-
-export function flashHazardPlane(){
-  if (!hazardPlane) return;
-  hazardPlane.material.opacity = 0.4;
-  setTimeout(() => hazardPlane.material.opacity = 0, 300);
-}

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ import { getHazardMesh, getHazardAttribute, allocHazard, freeHazard, dissolveHaz
 import { hitSound, missSound, penaltySound } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
-import { flashHit, flashMiss, createHazardPlane, flashHazardPlane } from './effects.js';
+import { flashHit, flashMiss, hazardFlash } from './effects.js';
 import { HitParticles } from './hitParticles.js';
 
 /* ============================ Renderer ============================ */
@@ -45,7 +45,6 @@ document.body.appendChild(
 scene.add(new THREE.HemisphereLight(0xffffff, 0x444444, 1.0));
 const hitParticles = new HitParticles();
 scene.add(hitParticles.points);
-createHazardPlane(camera);
 window.addEventListener('resize', () => {
   if (!renderer.xr.isPresenting) {
     renderer.setSize(window.innerWidth, window.innerHeight);
@@ -477,7 +476,7 @@ function onHazardHit(h){
   if (AUDIO_ENABLED) penaltySound();
   // Emphasize hazard impact with short, high-intensity rumble
   rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
-  flashHazardPlane();
+  hazardFlash.start();
   updateHUD();
 }
 
@@ -490,7 +489,7 @@ function onHazardFistHit(h){
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
   if (AUDIO_ENABLED) penaltySound();
   rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
-  flashHazardPlane();
+  hazardFlash.start();
   updateHUD();
 }
 


### PR DESCRIPTION
## Summary
- import and use new `hazardFlash` overlay in place of plane effect
- drop unused hazard plane helpers and their initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b972553040832eb655bc501fe44d55