### PR TITLE
Disable particle effects on hazard collisions

### DIFF
--- a/main.js
+++ b/main.js
@@ -473,7 +473,7 @@ function onBallMiss(b){
 function onHazardHit(h){
   h.alive=false;
   dissolveHazard(h.index, elapsed);
-  hitParticles.burst(h.position.clone());
+  // hitParticles.burst(h.position.clone());
   setTimeout(()=>freeHazard(h.index), DISSOLVE_DURATION*1000);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
   if (AUDIO_ENABLED) penaltySound();
@@ -488,7 +488,7 @@ function onHazardHit(h){
 function onHazardFistHit(h){
   h.alive=false;
   dissolveHazard(h.index, elapsed);
-  hitParticles.burst(h.position.clone());
+  // hitParticles.burst(h.position.clone());
   setTimeout(()=>freeHazard(h.index), DISSOLVE_DURATION*1000);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
   if (AUDIO_ENABLED) penaltySound();


### PR DESCRIPTION
## Summary
- Stop spawning hitParticles when hazards hit the player or fists
- Keep hitParticles for normal ball hits

## Testing
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b989d67bbc832e8f49fdce33535e19