### PR TITLE
Fix hazard orientation flag in hazard spawning

### DIFF
--- a/main.js
+++ b/main.js
@@ -407,7 +407,7 @@ function spawnHazard(sideSign){
     const velocity = _v2.copy(iForward).multiplyScalar(-tuning.hazardSpeed);
     const spin = (Math.random()<0.5?-1:1) * THREE.MathUtils.lerp(0.4,1.5,Math.random());
     const orientation = Math.random() < 0.5 ? 0 : 1;
-    const orientationFlag = orientation === 0 ? 1 : 0;
+    const orientationFlag = orientation;
     let driftAmp = 0, driftOmega = 0, driftPhase = 0;
     if (DRIFT_ENABLED){
       // Platzhalter für zukünftige Hazard-Drifts


### PR DESCRIPTION
## Summary
- pass orientation directly to instanced attribute when spawning hazards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba86399250832eb93de3294397d64b