### PR TITLE
Remove conditional hazard rotation

### DIFF
--- a/hazard.js
+++ b/hazard.js
@@ -28,7 +28,7 @@ function makeMaterial(m){
       '#include <begin_vertex>',
       `\nvec3 transformed = vec3(position);\n` + driftChunk +
       `float angle = instData.x * uTime;\nmat2 rot = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));\n`+
-      `if(instData.y > 0.5){\n  transformed.xz = rot * transformed.xz;\n}else{\n  transformed.yz = rot * transformed.yz;\n}\nvDissolve = dissolve;\n`
+      `transformed.yz = rot * transformed.yz;\nvDissolve = dissolve;\n`
     );
     shader.fragmentShader = `uniform float uTime;\nuniform float uDissolveDuration;\nvarying float vDissolve;\n` + shader.fragmentShader;
     shader.fragmentShader = shader.fragmentShader.replace(


### PR DESCRIPTION
## Summary
- Simplify hazard shader to rotate all instances around the X-axis
- Drop instanced rotation branching so vertical hazards tip forward as well

## Testing
- `node --check hazard.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba892e7a1c832ebed48e0a37e1a7d0