### PR TITLE
Add player body calibration settings

### DIFF
--- a/config.js
+++ b/config.js
@@ -59,3 +59,20 @@ export const GAME_MODE = 'endless';           // 'endless' | 'sprint60'
 export const SPRINT_DURATION = 60;            // Sekunden
 export const COMBO_STEP = 5;                  // alle 5 Treffer +1 Multiplikator
 export const COMBO_MAX_MULT = 5;              // max. x5
+
+// --- Player Body Configuration ---
+export let BODY_HEIGHT = 1.75;                // default body height in meters
+export let SHOULDER_WIDTH = 0.56;             // default shoulder width in meters
+export let BODY_CAPSULE_HEIGHT = 1.10;        // used for hazard collision (head to hip)
+export let BODY_CAPSULE_RADIUS = 0.28;        // half of default shoulder width
+
+export function setBodyConfig({ height, shoulderWidth } = {}) {
+  if (typeof height === 'number' && height > 0) {
+    BODY_HEIGHT = height;
+    BODY_CAPSULE_HEIGHT = height;
+  }
+  if (typeof shoulderWidth === 'number' && shoulderWidth > 0) {
+    SHOULDER_WIDTH = shoulderWidth;
+    BODY_CAPSULE_RADIUS = shoulderWidth / 2;
+  }
+}

--- a/main.js
+++ b/main.js
@@ -10,7 +10,9 @@ import {
   HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION,
   DEBUG_HAZARD_RING_MS,
   MIN_SPAWN_DISTANCE,
-  DISSOLVE_DURATION
+  DISSOLVE_DURATION,
+  BODY_CAPSULE_HEIGHT,
+  BODY_CAPSULE_RADIUS
 } from './config.js';
 
 import { createHUD } from './hud.js';
@@ -449,8 +451,7 @@ function spawnHazard(sideSign){
 }
 
 /* =================== Körperkapsel & Events =================== */
-// Capsule Head→Hip
-const BODY_CAPSULE_HEIGHT = 1.10, BODY_CAPSULE_RADIUS = 0.28;
+// Capsule Head→Hip (values configurable via config.js)
 const _bpHead = new THREE.Vector3(), _bpHip  = new THREE.Vector3();
 const _bpAB   = new THREE.Vector3(), _bpAP   = new THREE.Vector3();
 const _bpClosest = new THREE.Vector3(), _bpTmp  = new THREE.Vector3();

--- a/menu.js
+++ b/menu.js
@@ -1,5 +1,6 @@
 // Robustes Menü mit Hit-Plane, 2D-Picking und Zeitmodi
 import * as THREE from './three.js';
+import { BODY_CAPSULE_HEIGHT, BODY_CAPSULE_RADIUS, setBodyConfig } from './config.js';
 
 function makeCanvasPlane(w, h) {
   const canvas = document.createElement('canvas');
@@ -439,7 +440,23 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels) {
     if (kind==='speed'){ selSpeed=index; setSelected(speedButtons, selSpeed); return { action:'set-speed', value: selSpeed }; }
     if (kind==='dda'){ selDda=index; setSelected(ddaButtons, selDda); return { action:'set-dda', value: selDda }; }
     if (kind==='time'){ selTime=index; setSelected(timeButtons, selTime); return { action:'set-time', value: selTime }; }
-    if (kind==='start')   return { action:'start' };
+    if (kind==='start'){
+      try {
+        const hStr = window.prompt('Bitte Körpergröße in Metern eingeben:', BODY_CAPSULE_HEIGHT.toString());
+        const sStr = window.prompt('Bitte Schulterbreite in Metern eingeben:', (BODY_CAPSULE_RADIUS*2).toString());
+        const height = parseFloat(hStr);
+        const shoulder = parseFloat(sStr);
+        if (!isNaN(height) || !isNaN(shoulder)) {
+          setBodyConfig({
+            height: isNaN(height) ? undefined : height,
+            shoulderWidth: isNaN(shoulder) ? undefined : shoulder
+          });
+        }
+      } catch (e) {
+        // prompt not available; ignore and keep defaults
+      }
+      return { action:'start' };
+    }
     if (kind==='resume')  return { action:'resume' };
     if (kind==='restart') return { action:'restart' };
     if (kind==='quit')    return { action:'quit' };


### PR DESCRIPTION
## Summary
- Allow configuring body dimensions in config.js with default height and shoulder width
- Prompt for body height and shoulder width in menu start flow, updating config if provided
- Use configured capsule height and radius in main logic instead of hardcoded values

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ba99de769c832ebc1cdf8ed9fe18e2