### PR TITLE
Use floor offset for dynamic spawn height

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,7 +7,8 @@ export const SIDE_OFFSET_TIGHT = 0.25;  // m links/rechts (eng)
 export const TIGHT_PROB = 0.45;         // Wahrscheinlichkeit für "eng"
 export const BALL_SPEED = 1.6;          // m/s
 export const SPAWN_INTERVAL = 0.65;     // s
-export const SPAWN_MAX_BELOW = 0.70;    // m (max. 70 cm unter Headset)
+// Dynamische Spawn-Höhe basierend auf Körpergröße (z.B. Brusthöhe ~60 %)
+export const SPAWN_HEIGHT_RATIO = 0.6;  // Anteil der Körperhöhe für Spawns
 export const MISS_PLANE_OFFSET = 0.02;  // m vor der initialen Ebene
 export const SPAWN_BIAS = 0.20;         // m (20 cm näher zu dir, reduziert Wand-Occlusion)
 export const MIN_SPAWN_DISTANCE = 0.35; // m Mindestabstand zwischen Spawns
@@ -75,4 +76,20 @@ export function setBodyConfig({ height, shoulderWidth } = {}) {
     SHOULDER_WIDTH = shoulderWidth;
     BODY_CAPSULE_RADIUS = shoulderWidth / 2;
   }
+}
+
+// --- Floor Offset & Spawn Utilities ---
+// Gemessene Kopf-/Bodenhöhe (wird beim Setup aktualisiert)
+export let FLOOR_OFFSET = BODY_HEIGHT;
+
+export function setFloorOffset(offset) {
+  if (typeof offset === 'number' && offset > 0) {
+    FLOOR_OFFSET = offset;
+    BODY_HEIGHT = offset; // absolute Körpergröße merken
+  }
+}
+
+export function getSpawnMaxBelow() {
+  // Differenz zwischen Kopf und gewünschter Spawn-Höhe
+  return FLOOR_OFFSET * (1 - SPAWN_HEIGHT_RATIO);
 }

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ import { ARButton } from 'https://unpkg.com/three@0.166.1/examples/jsm/webxr/ARB
 
 import {
   BALL_RADIUS, FIST_RADIUS, SPAWN_DISTANCE, SIDE_OFFSET, SIDE_OFFSET_TIGHT,
-  BALL_SPEED, SPAWN_INTERVAL, SPAWN_MAX_BELOW, MISS_PLANE_OFFSET, SPAWN_BIAS,
+  BALL_SPEED, SPAWN_INTERVAL, MISS_PLANE_OFFSET, SPAWN_BIAS,
   DRIFT_ENABLED, DRIFT_MIN_AMPLITUDE, DRIFT_MAX_AMPLITUDE, DRIFT_MIN_FREQ, DRIFT_MAX_FREQ,
   AUDIO_ENABLED, HAPTICS_ENABLED,
   HAZARD_ENABLED, HAZARD_PROB, HAZARD_RADIUS, HAZARD_SPEED, HAZARD_PENALTY,
@@ -12,7 +12,9 @@ import {
   MIN_SPAWN_DISTANCE,
   DISSOLVE_DURATION,
   BODY_CAPSULE_HEIGHT,
-  BODY_CAPSULE_RADIUS
+  BODY_CAPSULE_RADIUS,
+  getSpawnMaxBelow,
+  setFloorOffset
 } from './config.js';
 
 import { createHUD } from './hud.js';
@@ -71,6 +73,7 @@ const iForward = new THREE.Vector3(), iUp = new THREE.Vector3(), iRight = new TH
 
 function lockInitialPose(){
   iPos.setFromMatrixPosition(camera.matrixWorld);
+  setFloorOffset(iPos.y); // Floor-Offset für Körpergröße ermitteln
   iQuat.copy(camera.quaternion);
   iForward.set(0,0,-1).applyQuaternion(iQuat).normalize();
   iUp.set(0,1,0).applyQuaternion(iQuat).normalize();
@@ -321,7 +324,7 @@ function spawnBall(sideSign,{style='auto'}={}){
     const side = (attempt%2===0 ? sideSign : -sideSign);
 
     let sideMag = Math.random() < 0.5 ? SIDE_OFFSET_TIGHT : SIDE_OFFSET;
-    let heightOffset = -Math.random() * SPAWN_MAX_BELOW;
+    let heightOffset = -Math.random() * getSpawnMaxBelow();
 
     // Extra breit/tief (nie beides)
     let extWide = Math.random() < tuning.wideProb;
@@ -401,7 +404,7 @@ function spawnHazard(sideSign){
   for (let attempt=0; attempt<MAX_SPAWN_TRIES; attempt++){
     const side = (attempt%2===0 ? sideSign : -sideSign);
     const sideMag = Math.random() < 0.5 ? SIDE_OFFSET : SIDE_OFFSET_TIGHT;
-    const heightOffset = -Math.random() * SPAWN_MAX_BELOW;
+    const heightOffset = -Math.random() * getSpawnMaxBelow();
     _v1.copy(iPos).addScaledVector(iForward, (SPAWN_DISTANCE - SPAWN_BIAS)).addScaledVector(iRight, sideMag*side).addScaledVector(iUp, heightOffset);
 
     if (!isSpawnPosClear(_v1)) continue;


### PR DESCRIPTION
## Summary
- Measure user's floor offset when locking initial pose to capture absolute body height
- Replace static SPAWN_MAX_BELOW with computed value based on floor offset and desired spawn height ratio
- Update ball and hazard spawns to use dynamic height

## Testing
- `node --check config.js main.js`
- `npm test` *(fails: Could not read package.json)*
- `node main.js` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9ac3d3f0832e9cd45235247c06db