### PR TITLE
Parse text input on blur to enable Start

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -453,6 +453,23 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels) {
     drawInputField(activeInput);
   });
 
+  hidden.addEventListener('blur', () => {
+    if (!activeInput) return;
+    const val = parseFloat(hidden.value);
+    if (!isNaN(val)){
+      if (activeInput === heightField){
+        heightVal = val;
+        sessionStorage.setItem('height', val.toString());
+        updateHeightField();
+      } else if (activeInput === shoulderField){
+        shoulderVal = val;
+        sessionStorage.setItem('shoulderWidth', val.toString());
+        updateShoulderField();
+      }
+      updateStartDisabled();
+    }
+  });
+
   function handleKeydown(e){
     if (!activeInput) return;
     if (e.key === 'Enter'){


### PR DESCRIPTION
## Summary
- parse hidden input on blur to update height and shoulder values
- enable the Start button after leaving input fields

## Testing
- `node --check menu.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab474b0d4832ea08fbedbd8d9ce1d