### PR TITLE
Allow comma decimal in input parsing

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -455,7 +455,7 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels) {
 
   hidden.addEventListener('blur', () => {
     if (!activeInput) return;
-    const val = parseFloat(hidden.value);
+    const val = parseFloat(hidden.value.replace(',', '.'));
     if (!isNaN(val)){
       if (activeInput === heightField){
         heightVal = val;


### PR DESCRIPTION
## Summary
- Parse menu input fields with commas as decimal separators by replacing commas with dots before parsing

## Testing
- `node -e \"console.log(parseFloat('1,78'.replace(',', '.')));\"`


------
https://chatgpt.com/codex/tasks/task_e_68bab7483530832ea4b378f4c666c625