### PR TITLE
Adjust body capsule radius with shoulder width offset

### DIFF
--- a/config.js
+++ b/config.js
@@ -65,7 +65,8 @@ export const COMBO_MAX_MULT = 5;              // max. x5
 export let BODY_HEIGHT = 1.75;                // default body height in meters
 export let SHOULDER_WIDTH = 0.56;             // default shoulder width in meters
 export let BODY_CAPSULE_HEIGHT = 1.10;        // used for hazard collision (head to hip)
-export let BODY_CAPSULE_RADIUS = 0.28;        // half of default shoulder width
+// Reduced radius to delay hazard collisions until actual body contact (~15 cm less)
+export let BODY_CAPSULE_RADIUS = 0.13;        // half of default shoulder width minus 0.15 m
 
 export function setBodyConfig({ height, shoulderWidth } = {}) {
   if (typeof height === 'number' && height > 0) {
@@ -74,7 +75,8 @@ export function setBodyConfig({ height, shoulderWidth } = {}) {
   }
   if (typeof shoulderWidth === 'number' && shoulderWidth > 0) {
     SHOULDER_WIDTH = shoulderWidth;
-    BODY_CAPSULE_RADIUS = shoulderWidth / 2;
+    // Use shoulder width with a 0.15 m inward offset, ensure radius stays positive
+    BODY_CAPSULE_RADIUS = Math.max((shoulderWidth / 2) - 0.15, 0.01);
   }
 }
 


### PR DESCRIPTION
## Summary
- Reduce default BODY_CAPSULE_RADIUS to 0.13 for closer hazard detection.
- Update setBodyConfig to subtract 0.15 m from half shoulder width and enforce a positive minimum.

## Testing
- `node --input-type=module -e "import('./config.js').then(m=>console.log('radius',m.BODY_CAPSULE_RADIUS))"`
- `node --input-type=module -e "import('./config.js').then(m=>{m.setBodyConfig({shoulderWidth:1.0});console.log('radius',m.BODY_CAPSULE_RADIUS);})"`
- `node --input-type=module -e "import('./config.js').then(m=>{m.setBodyConfig({shoulderWidth:0.2});console.log('radius',m.BODY_CAPSULE_RADIUS);})"`


------
https://chatgpt.com/codex/tasks/task_e_68babe522ab4832ea500c30bc6c0681f