### PR TITLE
Add gender selection for shoulder width

### DIFF
--- a/config.js
+++ b/config.js
@@ -63,7 +63,7 @@ export const COMBO_MAX_MULT = 5;              // max. x5
 
 // --- Player Body Configuration ---
 export let BODY_HEIGHT = 1.75;                // default body height in meters
-export let SHOULDER_WIDTH = 0.56;             // default shoulder width in meters
+export let SHOULDER_WIDTH = 0.47;             // default shoulder width in meters
 export let BODY_CAPSULE_HEIGHT = 1.10;        // used for hazard collision (head to hip)
 // Reduced radius to delay hazard collisions until actual body contact (~15 cm less)
 export let BODY_CAPSULE_RADIUS = 0.13;        // half of default shoulder width minus 0.15 m


### PR DESCRIPTION
## Summary
- Replace shoulder width input with male/female buttons that store shoulder width and gender in session storage
- Update menu layout and interaction to work with gender buttons
- Set default shoulder width to 0.47 m in config

## Testing
- `node --check menu.js`
- `node --check config.js`


------
https://chatgpt.com/codex/tasks/task_e_68bac14010e4832ea095f5c777655d3c