### PR TITLE
feat: add background music playback

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -1,4 +1,8 @@
+import { AUDIO_ENABLED, MUSIC_ENABLED, setBpm } from './config.js';
+import { resetBeats } from './beat.js';
+
 let ctx = null;
+let musicSource = null;
 
 function ensureCtx() {
   if (!ctx) {
@@ -27,3 +31,73 @@ export function hitSound()  { blip(700, 90, 'triangle', 0.08); }
 export function missSound() { blip(420, 70, 'sine',     0.05); }
 // Penalty = tiefer + leicht länger
 export function penaltySound(){ blip(220, 120, 'sawtooth', 0.08); }
+
+function getPeaksAtThreshold(data, threshold){
+  const peaks = [];
+  for (let i = 0; i < data.length; i++){
+    if (data[i] > threshold){
+      peaks.push(i);
+      i += 10000; // skip forward to avoid multiple detections
+    }
+  }
+  return peaks;
+}
+
+function countIntervalsBetweenNearbyPeaks(peaks){
+  const intervals = [];
+  for (let i = 0; i < peaks.length; i++){
+    for (let j = i + 1; j < peaks.length && j < i + 10; j++){
+      intervals.push(peaks[j] - peaks[i]);
+    }
+  }
+  return intervals;
+}
+
+function groupNeighborsByTempo(intervals, sampleRate){
+  const tempoCounts = {};
+  intervals.forEach(interval => {
+    let theoreticalTempo = 60 * sampleRate / interval;
+    while (theoreticalTempo < 90) theoreticalTempo *= 2;
+    while (theoreticalTempo > 180) theoreticalTempo /= 2;
+    const tempo = Math.round(theoreticalTempo);
+    tempoCounts[tempo] = (tempoCounts[tempo] || 0) + 1;
+  });
+  return Object.entries(tempoCounts).map(([tempo, count]) => ({ tempo: +tempo, count }))
+    .sort((a,b) => b.count - a.count);
+}
+
+function estimateBpm(buffer){
+  const data = buffer.getChannelData(0);
+  const peaks = getPeaksAtThreshold(data, 0.9);
+  const intervals = countIntervalsBetweenNearbyPeaks(peaks);
+  const groups = groupNeighborsByTempo(intervals, buffer.sampleRate);
+  return groups.length ? groups[0].tempo : 120;
+}
+
+export async function playMusic(url){
+  if (!AUDIO_ENABLED || !MUSIC_ENABLED) return;
+  if (!ensureCtx()) return;
+  if (musicSource){ musicSource.stop(); musicSource.disconnect(); }
+  try {
+    const res = await fetch(url);
+    const buf = await res.arrayBuffer();
+    const audioBuffer = await ctx.decodeAudioData(buf);
+    const bpm = estimateBpm(audioBuffer);
+    setBpm(bpm);
+    resetBeats();
+    musicSource = ctx.createBufferSource();
+    musicSource.buffer = audioBuffer;
+    musicSource.connect(ctx.destination);
+    musicSource.start();
+  } catch(err){
+    console.error('playMusic failed', err);
+  }
+}
+
+export function stopMusic(){
+  if (musicSource){
+    try{ musicSource.stop(); }catch{}
+    musicSource.disconnect();
+    musicSource = null;
+  }
+}

--- a/beat.js
+++ b/beat.js
@@ -3,6 +3,10 @@ import { BEAT_DURATION } from './config.js';
 const listeners = { 1:new Set(), 2:new Set(), 4:new Set() };
 const timers = { 1:0, 2:0, 4:0 };
 
+export function resetBeats(){
+  for (const sub of [1,2,4]) timers[sub] = 0;
+}
+
 export function onBeat(subdivision, fn){
   if (!listeners[subdivision]) return () => {};
   listeners[subdivision].add(fn);

--- a/config.js
+++ b/config.js
@@ -8,10 +8,17 @@ export const TIGHT_PROB = 0.45;         // Wahrscheinlichkeit für "eng"
 export const BALL_SPEED = 1.6;          // m/s
 export const SPAWN_INTERVAL = 0.65;     // s
 // --- Beat / Rhythm ---
-export const BPM = 92;
-export const BEAT_DURATION = 60 / BPM;            // Sekunden pro Beat
-export const HALF_BEAT_DURATION = BEAT_DURATION / 2;
-export const QUARTER_BEAT_DURATION = BEAT_DURATION / 4;
+export const DEFAULT_BPM = 92;
+export let BPM = DEFAULT_BPM;
+export let BEAT_DURATION = 60 / BPM;            // Sekunden pro Beat
+export let HALF_BEAT_DURATION = BEAT_DURATION / 2;
+export let QUARTER_BEAT_DURATION = BEAT_DURATION / 4;
+export function setBpm(bpm){
+  BPM = bpm;
+  BEAT_DURATION = 60 / bpm;
+  HALF_BEAT_DURATION = BEAT_DURATION / 2;
+  QUARTER_BEAT_DURATION = BEAT_DURATION / 4;
+}
 export let BEAT_SNAP_ENABLED = true;
 export function setBeatSnapEnabled(v){ BEAT_SNAP_ENABLED = !!v; }
 // Dynamische Spawn-Höhe basierend auf Körpergröße (z.B. Brusthöhe ~60 %)
@@ -41,6 +48,9 @@ export const DRIFT_MAX_FREQ = 1.6;       // Hz
 // --- Audio/Haptics ---
 export const AUDIO_ENABLED = true;
 export const HAPTICS_ENABLED = true;
+export let MUSIC_ENABLED = true;
+export const MUSIC_URL = './assets/music.mp3';
+export function setMusicEnabled(v){ MUSIC_ENABLED = !!v; }
 
 // --- Effects ---
 export const DISSOLVE_DURATION = 0.4;  // s

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ import {
   BALL_RADIUS, FIST_RADIUS, SPAWN_DISTANCE, SIDE_OFFSET, SIDE_OFFSET_TIGHT,
   BALL_SPEED, SPAWN_INTERVAL, MISS_PLANE_OFFSET, SPAWN_BIAS,
   DRIFT_ENABLED, DRIFT_MIN_AMPLITUDE, DRIFT_MAX_AMPLITUDE, DRIFT_MIN_FREQ, DRIFT_MAX_FREQ,
-  AUDIO_ENABLED, HAPTICS_ENABLED,
+  AUDIO_ENABLED, HAPTICS_ENABLED, MUSIC_ENABLED, MUSIC_URL,
   HAZARD_ENABLED, HAZARD_PROB, HAZARD_RADIUS, HAZARD_SPEED, HAZARD_PENALTY,
   HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION,
   DEBUG_HAZARD_RING_MS,
@@ -17,19 +17,21 @@ import {
   setFloorOffset,
   BEAT_DURATION,
   BEAT_SNAP_ENABLED,
-  setBeatSnapEnabled
+  setBeatSnapEnabled,
+  setBpm,
+  DEFAULT_BPM
 } from './config.js';
 
 import { createHUD } from './hud.js';
 import { FistsManager } from './fists.js';
 import { loadBall, isBallReady, getBallMesh, getBallAttribute, allocBall, freeBall, dissolveBall } from './ball.js';
 import { loadHazard, isHazardReady, getHazardMesh, getHazardAttribute, getHazardAxisAttribute, allocHazard, freeHazard, dissolveHazard } from './hazard.js';
-import { hitSound, missSound, penaltySound } from './audio.js';
+import { hitSound, missSound, penaltySound, playMusic } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
 import { flashHit, flashMiss, hazardFlash } from './effects.js';
 import { HitParticles } from './hitParticles.js';
-import { onBeat, updateBeats } from './beat.js';
+import { onBeat, updateBeats, resetBeats } from './beat.js';
 
 /* ============================ Renderer ============================ */
 const renderer = new THREE.WebGLRenderer({
@@ -207,6 +209,12 @@ function beginCountdown(){
   const note = `${DIFF_LABELS[sel.difficultyIndex]} · ${SPEED_LABELS[sel.speedIndex]} · ${TIME_LABELS[sel.timeIndex]} · ${DDA_LABELS[sel.ddaIndex]} · ${BEAT_LABELS[sel.beatIndex]}`;
   hud.set({ note });
   hardResetRound(); menu.setVisible(false); setLasersVisible(false); hideBackToMenuButton();
+  if (MUSIC_ENABLED && MUSIC_URL){
+    playMusic(MUSIC_URL);
+  } else {
+    setBpm(DEFAULT_BPM);
+    resetBeats();
+  }
   game.menuActive=false; ensureCountdownPlane(); placeCountdown();
   countdown.active=true; countdown.time=3.999; countdown.lastDrawn=-1; drawCountdown(3);
 }


### PR DESCRIPTION
## Summary
- add AudioContext-based `playMusic` to load tracks and estimate BPM
- allow enabling/disabling music via config and sync beat scheduler tempo
- reset beat timers for track tempo and start music on game launch

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --check config.js`
- `node --check audio.js`
- `node --check beat.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bafc4a92dc832eb8f81c057a2e001f