### PR TITLE
Remove endless mode and default to timed sessions

### DIFF
--- a/config.js
+++ b/config.js
@@ -73,7 +73,7 @@ export const HAZARD_RUMBLE_DURATION = 55;     // ms, kurz und kräftig
 export const DEBUG_HAZARD_RING_MS = 0;      // 0 = aus; kurzer Ring-Flash am Hazard-Spawn
 
 // --- Game Modes ---
-export const GAME_MODE = 'endless';           // 'endless' | 'sprint60'
+export const GAME_MODE = 'time60';            // 'time60' | 'time180' | 'time300'
 export const SPRINT_DURATION = 60;            // Sekunden
 export const COMBO_STEP = 5;                  // alle 5 Treffer +1 Multiplikator
 export const COMBO_MAX_MULT = 5;              // max. x5

--- a/hud.js
+++ b/hud.js
@@ -15,7 +15,7 @@ export function createHUD(scene){
 
   const state = {
     hits: 0, misses: 0, score: 0, streak: 0,
-    mode: 'endless', timeLeft: null, best: null,
+    mode: 'time60', timeLeft: 60, best: null,
     note: '' // kurze Hinweise wie "Zeit!"
   };
 
@@ -36,7 +36,15 @@ export function createHUD(scene){
 
     // Mode / Timer / Best
     ctx.font = 'bold 32px system-ui, Arial';
-    const modeTxt = state.mode === 'sprint60' ? 'Mode: Sprint 60s' : 'Mode: Endless';
+    let modeTxt = '';
+    switch (state.mode) {
+      case 'time180': modeTxt = 'Mode: 3:00'; break;
+      case 'time300': modeTxt = 'Mode: 5:00'; break;
+      case 'time60':
+      default:
+        modeTxt = 'Mode: 1:00';
+        break;
+    }
     ctx.fillText(modeTxt, 24, 104);
     if (state.timeLeft !== null) {
       ctx.fillStyle = state.timeLeft <= 5 ? '#ffcc00' : '#cfe8ff';

--- a/main.js
+++ b/main.js
@@ -155,7 +155,7 @@ function rumble(intensity=0.8, durationMs=60){
 /* =================== Menü / Presets / Zeitmodi =================== */
 const DIFF_LABELS = ['Anfänger','Aufsteiger','Profi'];
 const SPEED_LABELS = ['Langsam','Mittel','Schnell'];
-const TIME_LABELS  = ['Endlos','1:00','3:00','5:00'];
+const TIME_LABELS  = ['1:00','3:00','5:00'];
 const DDA_LABELS  = ['Aus','50%','100%'];
 const BEAT_LABELS = ['Aus','An'];
 
@@ -251,8 +251,8 @@ const DDA_CFG = {
 let ddaTimer = 0;
 let lastDdaHits = 0, lastDdaMisses = 0, lastDdaHazHits = 0;
 
-let gameMode = 'endless'; // 'endless' | 'time60' | 'time180' | 'time300'
-let timeLeft = null;
+let gameMode = 'time60'; // 'time60' | 'time180' | 'time300'
+let timeLeft = 60;
 
 function clamp(v, a, b){ return Math.max(a, Math.min(b, v)); }
 
@@ -273,11 +273,10 @@ function applyGamePreset(diffName, speedName, timeLabel){
   tuning.hazardSpeed = HAZARD_SPEED * sMul;
   tuning.hazardProb  = baseHazardProb;
 
-  if (timeLabel==='Endlos'){ gameMode='endless'; timeLeft=null; }
-  else if (timeLabel==='1:00'){ gameMode='time60'; timeLeft=60; }
+  if (timeLabel==='1:00'){ gameMode='time60'; timeLeft=60; }
   else if (timeLabel==='3:00'){ gameMode='time180'; timeLeft=180; }
   else if (timeLabel==='5:00'){ gameMode='time300'; timeLeft=300; }
-  else { gameMode='endless'; timeLeft=null; }
+  else { gameMode='time60'; timeLeft=60; }
 
   // DDA Reset
   ddaTimer = 0;

--- a/menu.js
+++ b/menu.js
@@ -543,9 +543,9 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
 
   let selDiff = loadIdx('selDiff', diffLabels.length, 0);
   let selSpeed = loadIdx('selSpeed', speedLabels.length, 1);
-  let selTime  = loadIdx('selTime',  timeLabels.length, 0);
+  let selTime  = loadIdx('selTime', 3, 0);
   let selBeat  = loadIdx('selBeat',  beatLabels.length, 1);
-  let selDda = 2; // Endlos default, DDA 100%
+  let selDda = 2; // DDA 100%
   const setSelected = (arr, idx) => arr.forEach((b,i)=>{ b.userData.selected=(i===idx); drawButton(b); });
   setSelected(diffButtons, selDiff);
   setSelected(speedButtons, selSpeed);


### PR DESCRIPTION
## Summary
- drop "Endlos" option and limit time modes to 1:00, 3:00 and 5:00
- default game mode to 60s and adjust HUD/menu accordingly
- use time-based mode labels instead of "Endless"

## Testing
- `npm test` *(fails: package.json missing)*
- `for f in main.js config.js hud.js menu.js; do node --check $f && echo "$f ok"; done`

------
https://chatgpt.com/codex/tasks/task_e_68bb2a2ca3bc832eb9a9b89bd031ad5f