### PR TITLE
Add dynamic music selection per time mode

### DIFF
--- a/assets/music/1_min/manifest.json
+++ b/assets/music/1_min/manifest.json
@@ -1,0 +1,7 @@
+[
+  {"name":"Dancing on the Waves","file":"dancing-on-the-waves-background-tropical-house-music-for-video-60sec-305967.mp3"},
+  {"name":"Drunk on Funk","file":"drunk-on-funk-273910.mp3"},
+  {"name":"Funky Fever","file":"funky-fever-1st-387582.mp3"},
+  {"name":"Music","file":"music.mp3"},
+  {"name":"On the Verge","file":"on-the-verge-epic-background-music-for-video-hip-hop-version-1min-316864.mp3"}
+]

--- a/assets/music/3_min/manifest.json
+++ b/assets/music/3_min/manifest.json
@@ -1,0 +1,5 @@
+[
+  {"name":"Consumer","file":"consumer-206554.mp3"},
+  {"name":"Cunk on Earth","file":"cunk-on-earth-k-pop-music-139107.mp3"},
+  {"name":"Rebel Inside","file":"rebel-inside-301928.mp3"}
+]

--- a/assets/music/5_min/manifest.json
+++ b/assets/music/5_min/manifest.json
@@ -1,0 +1,4 @@
+[
+  {"name":"Eleventh Hour","file":"modern-rnb-eleventh-hour-15675.mp3"},
+  {"name":"Dream On","file":"vic-fer-dream-on-396111.mp3"}
+]

--- a/main.js
+++ b/main.js
@@ -198,6 +198,7 @@ function placeCountdown(){
 }
 function beginCountdown(){
   const sel = menu.getSelection();
+  game.songUrl = sel.songUrl || null;
   applyGamePreset(
     DIFF_LABELS[sel.difficultyIndex],
     SPEED_LABELS[sel.speedIndex],
@@ -214,7 +215,7 @@ function beginCountdown(){
 }
 
 /* =================== Game-State / Tuning + DDA =================== */
-const game = { menuActive:true, running:false };
+const game = { menuActive:true, running:false, songUrl:null };
 
 const tuning = {
   spawnInterval: SPAWN_INTERVAL,
@@ -742,7 +743,7 @@ function loop(){
     drawCountdown(n); placeCountdown();
     if (countdown.time<=0){
       countdown.active=false; countdown.plane.visible=false; hud.plane.visible=true; game.running=true;
-      if (MUSIC_ENABLED && MUSIC_URL){ playMusic(MUSIC_URL); }
+      if (MUSIC_ENABLED && (game.songUrl || MUSIC_URL)){ playMusic(game.songUrl || MUSIC_URL); }
       else { setBpm(DEFAULT_BPM); resetBeats(); }
       updateHUD('');
     }


### PR DESCRIPTION
## Summary
- add dedicated music panel next to time settings
- load track lists from per-mode manifests and expose song buttons
- keep chosen song in menu state and play it when countdown ends

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2edb8e10832eb74a00768cc5f8e2