### PR TITLE
Load songs from manifest and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Punch-Ball
+
+## Build & Deployment
+
+The game runs as a static web application. To deploy, serve the repository contents with any static file server.
+
+### Adding music tracks
+
+Music is organised by time mode under `assets/music/<mode>` (e.g. `1_min`, `3_min`, `5_min`). Each folder contains a `manifest.json` listing the available tracks with their display name and filename. Whenever new songs are added, update the appropriate manifest file so the menu can load them.
+

--- a/menu.js
+++ b/menu.js
@@ -559,7 +559,6 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
   ddaButtons.forEach((b,i)=>{ b.position.set(positionsX[i], rowY_dda, 0.007); group.add(b); });
   beatButtons.forEach((b,i)=>{ b.position.set(positionsX[i], rowY_beat, 0.007); group.add(b); });
   timeButtons.forEach((b,i)=>{ b.position.set(positionsX[i], rowY_time, 0.007); group.add(b); });
-  loadSongsForTime(selTime);
 
   // Größe und Geschlecht
   heightField.position.set(positionsX[0], rowY_body, 0.007);
@@ -596,6 +595,7 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
   ls?.setItem('selTime', selTime.toString());
   ls?.setItem('selBeat', selBeat.toString());
   if (selGender >= 0) setSelected(genderButtons, selGender);
+  loadSongsForTime(selTime);
 
   // Modus: 'prestart' | 'ingame'
   let mode = 'prestart';


### PR DESCRIPTION
## Summary
- Fetch song manifests for the selected time mode when the menu panel loads
- Document how to add new music and update manifest files

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb32381c2c832ebcae1a2be5923ac4