### PR TITLE
Expand menu hit plane to cover song panel

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -326,10 +326,10 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
 
   // Unsichtbare Hit-Plane knapp vor den Buttons für Ray-Treffer/Laser
   const hitPlane = new THREE.Mesh(
-    new THREE.PlaneGeometry(1.80, 2.70, 1, 1),
+    new THREE.PlaneGeometry(2.6, 2.70, 1, 1),
     new THREE.MeshBasicMaterial({ transparent:true, opacity:0.0, depthWrite:false })
   );
-  hitPlane.position.z = 0.006;
+  hitPlane.position.set(0.375, 0, 0.006);
   hitPlane.name = 'menuHitPlane';
   group.add(hitPlane);
 


### PR DESCRIPTION
## Summary
- Broaden the menu's invisible hit plane to 2.6 width
- Shift the hit plane right so its edge reaches the song panel for better laser interaction

## Testing
- `node --check menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb375b917c832ebd0cae293a8b0edc