### PR TITLE
Adjust pause menu layout and honor new song on restart

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,8 +196,9 @@ function placeCountdown(){
   _v2.copy(_v1).sub(iForward);
   countdown.plane.position.copy(_v1); countdown.plane.lookAt(_v2);
 }
-function beginCountdown(){
+function beginCountdown(songUrl){
   const sel = menu.getSelection();
+  game.songUrl = songUrl ?? sel.songUrl ?? null;
   applyGamePreset(
     DIFF_LABELS[sel.difficultyIndex],
     SPEED_LABELS[sel.speedIndex],
@@ -584,9 +585,9 @@ for (const c of controllers){
     const hit = intersectHitPlane(c); if (!hit) return;
     const btn = menu.pickButtonAtWorldPoint(hit.point);
     const action = menu.click(btn); if (!action) return;
-    if (action.action==='start'){ game.songUrl = action.songUrl || null; beginCountdown(); }
+    if (action.action==='start'){ beginCountdown(action.songUrl); }
     else if (action.action==='resume'){ closeMenuResume(); }
-    else if (action.action==='restart'){ game.songUrl = action.songUrl || null; beginCountdown(); }
+    else if (action.action==='restart'){ beginCountdown(action.songUrl); }
     else if (action.action==='quit'){ const s=renderer.xr.getSession?.(); if (s) s.end(); }
   });
 }

--- a/menu.js
+++ b/menu.js
@@ -552,8 +552,7 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
   const rowY_ddaLbl   = rowY_dda   + 0.12;
   const rowY_beatLbl  = rowY_beat  + 0.12;
   const rowY_timeLbl  = rowY_time  + 0.10;
-  const rowY_ctrl1  = -0.72; // restart
-  const rowY_ctrl2  = -0.80; // start/resume/quit
+  const rowY_ctrl   = -0.80; // Steuer-Buttons
   const positionsX  = [-0.70, 0, 0.70];
   // Position the song selection panel with a small gap to the right of the main menu
   const songPanelX = 1.55;
@@ -577,10 +576,10 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
   genderFemaleBtn.position.set(positionsX[2], rowY_body, 0.007);
   group.add(heightField, genderMaleBtn, genderFemaleBtn);
 
-  resumeBtn.position.set(-0.35, rowY_ctrl2, 0.007);
-  restartBtn.position.set(0, rowY_ctrl1, 0.007);
-  startBtn.position.set(-0.35, rowY_ctrl2, 0.007);
-  quitBtn.position.set(0.35, rowY_ctrl2, 0.007);
+  resumeBtn.position.set(positionsX[0], rowY_ctrl, 0.007);
+  restartBtn.position.set(positionsX[2], rowY_ctrl, 0.007);
+  startBtn.position.set(positionsX[0], rowY_ctrl, 0.007);
+  quitBtn.position.set(positionsX[1], rowY_ctrl, 0.007);
   group.add(resumeBtn, restartBtn, startBtn, quitBtn);
 
   // Auswahlzustand


### PR DESCRIPTION
## Summary
- Lay out pause menu controls in a single row with restart on the right for clarity
- Pass selected song URL into the countdown so restarting uses the newly chosen track

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbccdb3a4c832e9f5b8dcd67689ca2