### PR TITLE
Resume suspended audio context

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -5,10 +5,8 @@ let ctx = null;
 let musicSource = null;
 
 function ensureCtx() {
-  if (!ctx) {
-    ctx = new (window.AudioContext || window.webkitAudioContext)();
-    if (ctx.state === 'suspended') ctx.resume();
-  }
+  if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
+  if (ctx.state === 'suspended') ctx.resume();
   return ctx;
 }
 


### PR DESCRIPTION
## Summary
- Always resume the audio context if it is suspended, even when already initialized

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd8981678832e94aaf553853fcdc3