### PR TITLE
Ensure countdown restarts with clean music

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ import {
   penaltySound,
   pauseMusic,
   resumeMusic,
+  stopMusic,
   preloadMusic,
   isMusicReady,
   startLoadedMusic
@@ -208,7 +209,10 @@ function placeCountdown(){
 function beginCountdown(){
   const sel = menu.getSelection();
   game.songUrl = sel.songUrl || null;
-  if (MUSIC_ENABLED && sel.songUrl) preloadMusic(sel.songUrl);
+  if (MUSIC_ENABLED && sel.songUrl) {
+    stopMusic();
+    preloadMusic(sel.songUrl);
+  }
   applyGamePreset(
     DIFF_LABELS[sel.difficultyIndex],
     SPEED_LABELS[sel.speedIndex],


### PR DESCRIPTION
## Summary
- Import and invoke `stopMusic` so any currently playing track stops before preloading new music at the start of a countdown.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfac9f788832e8874586a9beb76a8