### PR TITLE
Add Jab-Only mode

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -684,7 +684,12 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
   function click(btn){
     if (!btn || !btn.visible || btn.userData.disabled) return null;
     const { kind, index } = btn.userData;
-    if (kind==='difficulty'){ selDiff=index; setSelected(diffButtons, selDiff); ls?.setItem('selDiff', selDiff.toString()); return { action:'set-difficulty', value: selDiff }; }
+    if (kind==='difficulty'){
+      selDiff=index; setSelected(diffButtons, selDiff); ls?.setItem('selDiff', selDiff.toString());
+      const lbl = diffLabels[index];
+      const diffName = lbl === 'Jab-Only' ? 'JabOnly' : lbl;
+      return { action:'set-difficulty', value: selDiff, diffName };
+    }
     if (kind==='speed'){ selSpeed=index; setSelected(speedButtons, selSpeed); ls?.setItem('selSpeed', selSpeed.toString()); return { action:'set-speed', value: selSpeed }; }
     if (kind==='dda'){ selDda=index; setSelected(ddaButtons, selDda); return { action:'set-dda', value: selDda }; }
     if (kind==='beat'){ selBeat=index; setSelected(beatButtons, selBeat); ls?.setItem('selBeat', selBeat.toString()); return { action:'set-beat', value: selBeat }; }

--- a/patterns.js
+++ b/patterns.js
@@ -20,6 +20,18 @@ function patRL(){
     { items:[{ side:L, style:'auto' }] },
   ]};
 }
+function patLRStraight(){
+  return { name:'LRStraight', steps:[
+    { items:[{ side:L, style:'straight' }] },
+    { items:[{ side:R, style:'straight' }] },
+  ]};
+}
+function patRLStraight(){
+  return { name:'RLStraight', steps:[
+    { items:[{ side:R, style:'straight' }] },
+    { items:[{ side:L, style:'straight' }] },
+  ]};
+}
 function patDoubleStraight(){
   // Doppelfaust – zwei gerade gleichzeitig
   return { name:'DoubleStraight', steps:[
@@ -81,6 +93,11 @@ const POOLS = {
     patS_V, patS_V, patS_V, patS_V,
     patMixStraightThenS, patMixStraightThenS, patMixStraightThenS,
     patTriplet, patTriplet
+  ],
+  'JabOnly': [
+    patLRStraight, patLRStraight,
+    patRLStraight, patRLStraight,
+    patDoubleStraight
   ]
 };
 


### PR DESCRIPTION
## Summary
- add Jab-Only pattern pool with straight-only sequences
- support Jab-Only difficulty in presets and apply straight-only tuning
- wire menu difficulty button to trigger Jab-Only preset

## Testing
- `node --check patterns.js`
- `node --check main.js`
- `node --check menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e3408d0832eb9dd62aa785a0bc9