### PR TITLE
Add Doppelfaust double-punch mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -165,18 +165,18 @@ function rumble(intensity=0.8, durationMs=60){
 }
 
 /* =================== Menü / Presets / Zeitmodi =================== */
-const DIFF_LABELS = ['Anfänger','Aufsteiger','Profi','Jab-Only'];
+const DIFF_LABELS = ['Anfänger','Aufsteiger','Profi','Doppelfaust','Jab-Only'];
 const SPEED_LABELS = ['Langsam','Mittel','Schnell'];
 const TIME_LABELS  = ['1:00','3:00','5:00'];
 const DDA_LABELS  = ['Aus','50%','100%'];
 const BEAT_LABELS = ['Aus','An'];
 
-const DIFFICULTY_STRAIGHT_SHARE = { 'Anfänger':1.00, 'Aufsteiger':0.70, 'Profi':0.25, 'JabOnly':1.00 };
+const DIFFICULTY_STRAIGHT_SHARE = { 'Anfänger':1.00, 'Aufsteiger':0.70, 'Profi':0.25, 'Doppelfaust':1.00, 'JabOnly':1.00 };
 const SPEED_PRESETS = { 'Langsam':0.85, 'Mittel':1.0, 'Schnell':1.25 };
 
 // Extreme (immer gerade)
 const WIDE_EXT_M = 0.20, DEEP_EXT_M = 0.20;
-const EXT_PROB = { 'Anfänger':{wide:0.05,deep:0.05}, 'Aufsteiger':{wide:0.12,deep:0.12}, 'Profi':{wide:0.22,deep:0.22}, 'JabOnly':{wide:0.0,deep:0.0} };
+const EXT_PROB = { 'Anfänger':{wide:0.05,deep:0.05}, 'Aufsteiger':{wide:0.12,deep:0.12}, 'Profi':{wide:0.22,deep:0.22}, 'Doppelfaust':{wide:0.0,deep:0.0}, 'JabOnly':{wide:0.0,deep:0.0} };
 
 // Vertikale S-Kurve: sanfter Downtrend
 const VDRIFT_BIAS_MIN = 0.05, VDRIFT_BIAS_MAX = 0.15;
@@ -284,8 +284,12 @@ function applyGamePreset(diffName, speedName, timeLabel){
   // auf Basiswerte zurück
   tuning.spawnInterval = baseSpawnInterval;
   tuning.straightShare = baseStraightShare;
-  if (diffName === 'JabOnly') {
+  if (diffName === 'JabOnly' || diffName === 'Doppelfaust') {
     tuning.straightShare = 1.0;
+  }
+  if (diffName === 'Doppelfaust') {
+    // etwas längere Pausen für simultane Treffer
+    tuning.spawnInterval *= 1.25;
   }
   const ext = EXT_PROB[diffName] ?? EXT_PROB['Aufsteiger'];
   tuning.wideProb = ext.wide; tuning.deepProb = ext.deep;

--- a/menu.js
+++ b/menu.js
@@ -701,7 +701,11 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
     if (kind==='difficulty'){
       selDiff=index; setSelected(diffButtons, selDiff); ls?.setItem('selDiff', selDiff.toString());
       const lbl = diffLabels[index];
-      const diffName = lbl === 'Jab-Only' ? 'JabOnly' : lbl;
+      const diffName = lbl === 'Jab-Only'
+        ? 'JabOnly'
+        : lbl === 'Doppelfaust'
+          ? 'Doppelfaust'
+          : lbl;
       return { action:'set-difficulty', value: selDiff, diffName };
     }
     if (kind==='speed'){ selSpeed=index; setSelected(speedButtons, selSpeed); ls?.setItem('selSpeed', selSpeed.toString()); return { action:'set-speed', value: selSpeed }; }

--- a/patterns.js
+++ b/patterns.js
@@ -94,6 +94,10 @@ const POOLS = {
     patMixStraightThenS, patMixStraightThenS, patMixStraightThenS,
     patTriplet, patTriplet
   ],
+  'Doppelfaust': [
+    // ausschließlich simultane Geraden
+    patDoubleStraight
+  ],
   'JabOnly': [
     patLRStraight, patLRStraight,
     patRLStraight, patRLStraight,


### PR DESCRIPTION
## Summary
- add `Doppelfaust` pool containing only simultaneous straight punches
- expose new `Doppelfaust` difficulty in menu and tuning
- lengthen spawn interval for `Doppelfaust` to focus on double punches

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js && node --check patterns.js && node --check menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc1931b07c832ebf755bb9c229f7f0