### PR TITLE
Improve calorie estimation with weight scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ The game runs as a static web application. To deploy, serve the repository conte
 
 Music is organised by time mode under `assets/music/<mode>` (e.g. `1_min`, `3_min`, `5_min`). Each folder contains a `manifest.json` listing the available tracks with their display name and filename. Whenever new songs are added, update the appropriate manifest file so the menu can load them.
 
+### Calorie calculation
+
+Calorie burn is estimated from movement speed and hits. The constants in `config.js` are calibrated for a 70&nbsp;kg player. To adapt the estimation to a different body weight, call `setUserWeight(weightInKg)` or change `USER_WEIGHT` directly in the config.
+

--- a/config.js
+++ b/config.js
@@ -78,8 +78,13 @@ export const COMBO_STEP = 5;                  // alle 5 Treffer +1 Multiplikator
 export const COMBO_MAX_MULT = 5;              // max. x5
 
 // --- Calories ---
-export const CAL_SPEED_FACTOR = 0.1;          // kcal contribution per m/s
-export const CAL_HIT_FACTOR   = 0.5;          // kcal bonus per hit
+export const CAL_SPEED_FACTOR = 0.05;         // kcal contribution per m/s (for 70 kg)
+export const CAL_HIT_FACTOR   = 0.2;          // kcal bonus per hit (for 70 kg)
+export const CAL_WEIGHT_REF   = 70;           // reference weight in kg
+export let   USER_WEIGHT      = CAL_WEIGHT_REF; // current player weight in kg
+export function setUserWeight(w) {
+  if (typeof w === 'number' && w > 0) USER_WEIGHT = w;
+}
 
 // --- Player Body Configuration ---
 export let BODY_HEIGHT = 1.75;                // default body height in meters

--- a/main.js
+++ b/main.js
@@ -21,7 +21,9 @@ import {
   setBpm,
   DEFAULT_BPM,
   CAL_SPEED_FACTOR,
-  CAL_HIT_FACTOR
+  CAL_HIT_FACTOR,
+  CAL_WEIGHT_REF,
+  USER_WEIGHT
 } from './config.js';
 
 import { createHUD } from './hud.js';
@@ -957,7 +959,8 @@ function loop(){
 
   if (loop._lastHits === undefined) loop._lastHits = 0;
   const hitsDelta = hits - loop._lastHits;
-  calories += CAL_SPEED_FACTOR * speedSum * dt + CAL_HIT_FACTOR * hitsDelta;
+  const weightFactor = USER_WEIGHT / CAL_WEIGHT_REF;
+  calories += (CAL_SPEED_FACTOR * speedSum * dt + CAL_HIT_FACTOR * hitsDelta) * weightFactor;
   loop._lastHits = hits;
 
   updateHUD(countdown.active ? '' : (game.menuActive ? 'Konfigurieren & Starten' : (backBtn.visible ? 'Zeit abgelaufen' : '')));


### PR DESCRIPTION
## Summary
- Scale calorie calculation by user weight and lower default factors
- Document calorie configuration in README

## Testing
- `node --check main.js`
- `node --check config.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2228e20c832ead42bf9b401ffbdd