### PR TITLE
Play flying sound on hazard spawn

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,8 @@ import {
   stopMusic,
   preloadMusic,
   isMusicReady,
-  startLoadedMusic
+  startLoadedMusic,
+  startFlying
 } from './audio.js';
 import { createMenu } from './menu.js';
 import { pickPattern } from './patterns.js'; // << NEU
@@ -504,6 +505,7 @@ function spawnHazard(sideSign){
       attr.array[aIndex+3] = 0;
     }
     attr.needsUpdate = true;
+    startFlying();
     return _v1.clone();
   }
 


### PR DESCRIPTION
## Summary
- Import `startFlying` from audio utilities
- Trigger `startFlying` when spawning hazards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc412d88b0832eb3fed6b159ff901b