### PR TITLE
Play crash sound for hazard collisions

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ import {
   hitSound,
   playKick,
   missSound,
-  penaltySound,
+  playCrash,
   pauseMusic,
   resumeMusic,
   stopMusic,
@@ -559,7 +559,7 @@ function onHazardHit(h){
   // hitParticles.burst(h.position.clone());
   setTimeout(()=>freeHazard(h.index), DISSOLVE_DURATION*1000);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
-  if (AUDIO_ENABLED) penaltySound();
+  if (AUDIO_ENABLED) playCrash();
   // Emphasize hazard impact with short, high-intensity rumble
   rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
   hazardFlash.start();
@@ -574,7 +574,7 @@ function onHazardFistHit(h){
   // hitParticles.burst(h.position.clone());
   setTimeout(()=>freeHazard(h.index), DISSOLVE_DURATION*1000);
   hazardHits++; streak=0; score=Math.max(0, score-HAZARD_PENALTY);
-  if (AUDIO_ENABLED) penaltySound();
+  if (AUDIO_ENABLED) playCrash();
   rumble(HAZARD_RUMBLE_INTENSITY, HAZARD_RUMBLE_DURATION);
   hazardFlash.start();
   hud.flashHazard();


### PR DESCRIPTION
## Summary
- Replace penalty sound with crash sound when hazards hit the player or fists
- Import crash sound utility in main.js
- Crash sound stops ongoing flying audio for cleaner feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc455795a0832e8b60c5c9c0efbff8