### PR TITLE
Add menu mode getter and restrict resume to ingame menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -766,7 +766,7 @@ function loop(){
       const gp=src.gamepad; if (!gp) continue;
       if (isRisingEdgeAX(gp, `${src.handedness}:AX`, loop._btnPrev)){
         if (game.running && !game.menuActive) openMenuIngame();
-        else if (game.menuActive)            closeMenuResume();
+        else if (game.menuActive && menu.getMode() === 'ingame') closeMenuResume();
       }
     }
   }
@@ -778,7 +778,7 @@ function loop(){
     const v = fistsMgr.isVGesture(i);
     if (v && !loop._vPrev[key]){
       if (game.running && !game.menuActive) openMenuIngame();
-      else if (game.menuActive)            closeMenuResume();
+      else if (game.menuActive && menu.getMode() === 'ingame') closeMenuResume();
     }
     loop._vPrev[key] = v;
   }

--- a/menu.js
+++ b/menu.js
@@ -623,6 +623,9 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
 
   // Modus: 'prestart' | 'ingame'
   let mode = 'prestart';
+  function getMode(){
+    return mode;
+  }
   function setMode(m){
     mode = m;
     const pre = (mode==='prestart');
@@ -752,5 +755,5 @@ export function createMenu(diffLabels, speedLabels, timeLabels, ddaLabels, beatL
     }
   }
 
-  return { group, panel, hitPlane, setVisible, placeAt, setMode, setHover, pickButtonAtWorldPoint, click, getSelection, updateAnimation };
+  return { group, panel, hitPlane, setVisible, placeAt, setMode, getMode, setHover, pickButtonAtWorldPoint, click, getSelection, updateAnimation };
 }


### PR DESCRIPTION
## Summary
- expose current menu mode via new `getMode` function
- limit A/X buttons and V gesture to close menu only when in-game pause menu

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/punch/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bc729eae14832e82fcbcd889c5de8d